### PR TITLE
Revert "ALSA: pcm: Avoid possible info leaks from PCM stream buffers"

### DIFF
--- a/sound/core/pcm_native.c
+++ b/sound/core/pcm_native.c
@@ -587,10 +587,6 @@ static int snd_pcm_hw_params(struct snd_pcm_substream *substream,
 					LONG_MAX - runtime->buffer_size)
 		runtime->boundary *= 2;
 
-	/* clear the buffer for avoiding possible kernel info leaks */
-	if (runtime->dma_area)
-		memset(runtime->dma_area, 0, runtime->dma_bytes);
-
 	snd_pcm_timer_resolution_change(substream);
 	snd_pcm_set_state(substream, SNDRV_PCM_STATE_SETUP);
 


### PR DESCRIPTION
This reverts commit 8c2c55c82ee4f5effe215a0383657b28257e1f9e.